### PR TITLE
Shot-by-shot measurement retrieval functionality.

### DIFF
--- a/qaoa/qaoa.py
+++ b/qaoa/qaoa.py
@@ -45,9 +45,6 @@ class OptResult:
     def compute_best_index(self):
         self.index_Exp_min = self.Exp.index(min(self.Exp))
 
-    def get_best_index(self):
-        return self.Exp.index(min(self.Exp))
-
     def get_best_Exp(self):
         return self.Exp[self.index_Exp_min]
 
@@ -57,15 +54,11 @@ class OptResult:
     def get_best_angles(self):
         return self.angles[self.index_Exp_min]
     
-    def get_all_angles(self):
-        return self.angles
-
     def num_fval(self):
         return len(self.Exp)
 
     def num_shots(self):
-        return sum(self.shots)
-    
+        return sum(self.shots)    
 
     def get_best_solution(self):
         best_cost = np.min(self.BestCost)
@@ -353,7 +346,7 @@ class QAOA:
                 self.stat.add_sample(cost, counts_list[string], string[::-1])
 
     def optimize(self, depth):
-        ## run local optimzation by iteratively increasing the depth until depth p is reached
+        ## run local optimization by iteratively increasing the depth until depth p is reached
         while self.current_depth < depth:
             if self.current_depth == 0:
                 if self.Exp_sampled_p1 is None:

--- a/qaoa/qaoa.py
+++ b/qaoa/qaoa.py
@@ -196,26 +196,6 @@ class QAOA:
             raise ValueError
         return self.optimization_results[depth].get_best_angles()
     
-    def get_all_values(self, depth):
-        if depth > self.current_depth + 1:
-            raise ValueError
-        return self.optimization_results[depth].get_all_vals()
-    
-    def get_all_solutions(self, depth):
-        if depth > self.current_depth + 1:
-            raise ValueError
-        return self.optimization_results[depth].get_all_sols()
-    
-    def get_all_angles(self, depth):
-        if depth > self.current_depth + 1:
-            raise ValueError
-        return self.optimization_results[depth].get_all_angles()
-    
-    def get_best_indices(self, depth):
-        if depth > self.current_depth + 1:
-            raise ValueError
-        return self.optimization_results[depth].get_best_index()
-    
     def get_memory_lists(self):
         return self.memory_lists
 

--- a/qaoa/util/statistic.py
+++ b/qaoa/util/statistic.py
@@ -19,12 +19,10 @@ class Statistic:
         self.E = 0
         self.S = 0
         self.all_values = np.array([])
-        self.memorylist = []
 
     def add_sample(self, value, weight, string):
         self.W += weight
         tmp_E = self.E
-
         if value >= self.maxval:
             if value == self.maxval:
                 self.maxSols.append(string)
@@ -47,9 +45,6 @@ class Statistic:
             self.all_values = np.insert(
                 self.all_values, idx, np.ones(int(weight)) * value
             )
-            
-    def add_memory(self, list):
-        self.memorylist.append(list)
 
     def get_E(self):
         return self.E
@@ -68,9 +63,6 @@ class Statistic:
     
     def get_min_sols(self):
         return self.minSols
-    
-    def get_memory(self):
-        return self.memorylist
 
     def get_CVaR(self):
         if self.cvar < 1:


### PR DESCRIPTION
Added a `memorysize` int parameter that, if set to N, allows to retrieve the first N measurement results together with a cost for each measurement. 
By defaults `memorysize` is set to -1, therefore the part of the code that implements this functionality will not be triggered, unless this value is set deliberately to a positive int when calling QAOA.

The function that finds the first `memorysize` measurement results is inside `measurementStatistics`. 
`get_memory_lists()` outputs a list of pairs of the form `[measurement_result, cost]`.